### PR TITLE
Add auto-generation of from_* impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ proc-macro = true
 [dependencies]
 syn = "0.11"
 quote = "0.3.10"
+heck = "0.3"
 
 [dev-dependencies]
 diesel = { version = "0.15.0", features = ["sqlite"] }

--- a/README.md
+++ b/README.md
@@ -33,9 +33,20 @@ pub struct Mycologist {
     id: i32,
     rust_count: i32,
 }
+
 #[derive(Debug)]
 pub struct NewMycologist {
     rust_count: i32,
+}
+
+impl Mycologist {
+    // The `pub` comes from the `pub` on `Mycologist`
+    pub fn from_new_mycologist(id: i32, base: NewMycologist) {
+        Mycologist {
+            id,
+            rust_count: base.rust_count,
+        }
+    }
 }
 
 pub struct Rust {
@@ -48,9 +59,30 @@ pub struct CapturedRust {
     mycologist_id: i32,
     life_cycle_stage: i32,
 }
+
 #[derive(Debug, PartialEq)]
 pub struct NewRust {
     life_cycle_stage: i32,
+}
+
+// Convenience constructors that take just the parameters that exist in
+// this intermediate and not the intermediate it came from.
+impl Rust {
+    pub fn from_captured_rust(id: i32, base: CapturedRust) -> Rust {
+        Rust {
+            id,
+            mycologist_id: base.mycologist_id,
+            life_cycle_stage: base.life_cycle_stage,
+        }
+    }
+
+    pub fn from_new_rust(id: i32, mycologist_id: i32, base: NewRust) -> Rust {
+        Rust {
+            id,
+            mycologist_id,
+            life_cycle_stage: base.life_cycle_stage,
+        }
+    }
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,17 @@ extern crate proc_macro;
 
 extern crate syn;
 
+extern crate heck;
 #[macro_use]
 extern crate quote;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::iter::FromIterator;
 
+use heck::SnakeCase;
 use proc_macro::TokenStream;
 use quote::Tokens;
-use syn::{Attribute, Body, DeriveInput, Field, Ident, MetaItem, NestedMetaItem};
+use syn::{Attribute, Body, DeriveInput, Field, Ident, MetaItem, NestedMetaItem, Visibility};
 
 const EXCLUDE: &str = "intermediate_exclude";
 const DERIVE: &str = "intermediate_derive";
@@ -18,7 +21,7 @@ const DIESEL_TABLE_NAME: &str = "table_name";
 
 #[proc_macro_derive(DieselIntermediate,
                     attributes(intermediate_exclude, intermediate_derive,
-                                 intermediate_table_name))]
+                               intermediate_table_name))]
 pub fn diesel_intermediate_fields(input: TokenStream) -> TokenStream {
     let source = input.to_string();
 
@@ -42,7 +45,7 @@ fn expand_diesel_intermediate_fields(ast: &DeriveInput) -> Tokens {
     let derive_attr = syn::parse_outer_attr(&derive_attr).unwrap();
 
     let table_name_attr = extract_table_name_attr(&ast.attrs);
-    let (common_fields, intermediates) = extract_intermediates(fields);
+    let intermediates = extract_intermediates(fields);
 
     let base_name = ast.ident.to_string();
 
@@ -50,7 +53,6 @@ fn expand_diesel_intermediate_fields(ast: &DeriveInput) -> Tokens {
 
     build_items(
         &ast.vis,
-        &common_fields,
         &intermediates,
         &derive_attr,
         &table_name_attr,
@@ -72,10 +74,10 @@ fn extract_table_name_attr(attrs: &[Attribute]) -> Option<Attribute> {
                 let table_name_attr = format!(r#"#[table_name = {}]"#, quote!(#literal));
 
                 return Some(syn::parse_outer_attr(&table_name_attr).unwrap());
-            },
+            }
             MetaItem::NameValue(ref ident, _) if ident == DIESEL_TABLE_NAME => {
                 found = Some(attr.clone());
-            },
+            }
             MetaItem::List(ref ident, _) if ident == OVERRIDE_TABLE_NAME => {
                 panic!(r#"expected [.. = "<table-name>"], not: {}"#, quote!(#attr));
             }
@@ -88,16 +90,35 @@ fn extract_table_name_attr(attrs: &[Attribute]) -> Option<Attribute> {
 
 fn build_items(
     vis: &syn::Visibility,
-    common_fields: &[&Field],
-    intermediates: &HashMap<String, Vec<Field>>,
+    intermediates: &IntermediateFields,
     derive_attr: &Attribute,
     table_name_attr: &Option<Attribute>,
+    // The name of the full struct that everything else is an intermediate for
     base_name: &str,
     impl_generics: &syn::ImplGenerics,
     where_clause: &syn::WhereClause,
 ) -> quote::Tokens {
     let new_name = Ident::new("New".to_owned() + base_name);
-    let mut new_structs = quote! {
+    let common_fields = &intermediates.common_fields;
+
+    // accumulator for all the gnerated code
+    let mut new_structs = quote!();
+
+    // add the impl <type> { from_<intermediates>... }
+    let field_difs = intermediates.field_differences_full();
+    new_structs = add_from_impls(
+        &Ident::new(base_name),
+        &base_name,
+        &intermediates,
+        vis,
+        field_difs,
+        new_structs,
+    );
+
+    // add the New<type> struct
+    new_structs = quote! {
+        #new_structs
+
         #derive_attr
         #table_name_attr
         #vis struct #new_name #impl_generics #where_clause {
@@ -105,8 +126,10 @@ fn build_items(
         }
     };
 
-    for (prefix, extra_fields) in intermediates {
+    // add the same as above but for every extra intermediate
+    for (prefix, extra_fields) in &intermediates.prefix_excluded {
         let this_name = Ident::new(prefix.clone() + &base_name);
+
         new_structs = quote! {
             #new_structs
 
@@ -116,9 +139,73 @@ fn build_items(
                 #(#extra_fields),* ,
                 #(#common_fields),*
             }
+        };
+
+        let field_difs = intermediates.field_differences(prefix);
+
+        new_structs = add_from_impls(
+            &this_name,
+            &base_name,
+            &intermediates,
+            vis,
+            field_difs,
+            new_structs,
+        );
+    }
+
+    new_structs
+}
+
+fn add_from_impls(
+    this_name: &Ident,
+    base_name: &str,
+    intermediates: &IntermediateFields,
+    vis: &Visibility,
+    field_differences: Vec<(String, Vec<&Field>, Vec<&Field>)>,
+    new_structs: quote::Tokens,
+) -> quote::Tokens {
+    let base_snake = base_name.to_snake_case();
+    let base_field_idents = &to_struct_assignment_form(&intermediates.common_fields);
+
+    let mut from_fns = quote!();
+    for (other_prefix, different_fields, same_fields) in field_differences {
+        let new_field_params: Vec<Field> = different_fields
+            .iter()
+            .cloned()
+            .map(|f| strip_vis_and_attrs(f.clone()))
+            .collect();
+        let new_field_names: Vec<Ident> = different_fields
+            .iter()
+            .flat_map(|f| f.ident.clone())
+            .collect();
+        let same_field_idents = to_struct_assignment_form_ref(&same_fields);
+        let from_ident = Ident::new(format!("{}{}", other_prefix, base_name));
+        let from_fn_ident = Ident::new(format!(
+            "from_{}_{}",
+            other_prefix.to_snake_case(),
+            base_snake,
+        ));
+
+        from_fns = quote! {
+            #from_fns
+
+            #vis fn #from_fn_ident(#(#new_field_params),* , base: #from_ident) -> #this_name {
+                #this_name {
+                    #(#new_field_names),* ,
+                    #(#base_field_idents),* ,
+                    #(#same_field_idents),*
+                }
+            }
+        };
+    }
+
+    quote! {
+        #new_structs
+
+        impl #this_name {
+            #from_fns
         }
     }
-    new_structs
 }
 
 /// Return the attrs, without any that have the `to_strip` ident
@@ -133,6 +220,37 @@ fn strip_attr(attrs: &[Attribute], to_strip: &str) -> Vec<Attribute> {
         })
         .collect::<Vec<_>>()
 }
+
+fn strip_vis_and_attrs(field: Field) -> Field {
+    Field {
+        ident: field.ident,
+        vis: syn::Visibility::Inherited,
+        attrs: vec![],
+        ty: field.ty,
+    }
+}
+
+fn to_struct_assignment_form(fields: &[Field]) -> Vec<Tokens> {
+    fields
+        .iter()
+        .map(|f| {
+            let ident = &f.ident;
+            quote! { #ident: base.#ident }
+        })
+        .collect()
+}
+
+
+fn to_struct_assignment_form_ref(fields: &[&Field]) -> Vec<Tokens> {
+    fields
+        .iter()
+        .map(|f| {
+            let ident = &f.ident;
+            quote! { #ident: base.#ident }
+        })
+        .collect()
+}
+
 
 fn extract_items(attrs: &[Attribute], attr: &str) -> Vec<String> {
     attrs
@@ -154,14 +272,16 @@ fn extract_items(attrs: &[Attribute], attr: &str) -> Vec<String> {
 }
 
 enum ExcludeAttr<'a> {
-    Excluded,
+    /// A field that is excluded from the `New` item
+    Excluded(Field),
+    /// A field that is excluded from a named item
     Intermediate(&'a str, Field),
     Included,
 }
 
-fn extract_intermediates(fields: &[Field]) -> (Vec<&Field>, HashMap<String, Vec<Field>>) {
-    let mut subtypes = HashMap::new();
-
+/// Parse the attributes on fields to get a list fields that should be excluded
+fn extract_intermediates(fields: &[Field]) -> IntermediateFields {
+    let mut intermediates = IntermediateFields::default();
     // Collect the fields that aren't decorated with "exclude"
     let common_fields = fields
         .iter()
@@ -169,9 +289,14 @@ fn extract_intermediates(fields: &[Field]) -> (Vec<&Field>, HashMap<String, Vec<
             use ExcludeAttr::*;
             // If any of this fields attrs are "exclude" then we want to strip the entire field
             match field_status(f) {
-                Excluded => false,
+                Excluded(field) => {
+                    intermediates.excluded_at_least_once.push(field);
+                    false
+                }
                 Intermediate(intermediate_prefix, field) => {
-                    subtypes
+                    intermediates.excluded_at_least_once.push(field.clone());
+                    intermediates
+                        .prefix_excluded
                         .entry(intermediate_prefix.to_string())
                         .or_insert_with(Vec::new)
                         .push(field);
@@ -180,8 +305,134 @@ fn extract_intermediates(fields: &[Field]) -> (Vec<&Field>, HashMap<String, Vec<
                 Included => true,
             }
         })
+        .cloned()
         .collect::<Vec<_>>();
-    (common_fields, subtypes)
+    intermediates.common_fields = common_fields;
+    intermediates
+}
+
+/// A list of all the fields on an original struct, grouped by their status
+#[derive(Default)]
+struct IntermediateFields {
+    /// The fields that never have an `#[intermediate_exclude]1 field on them
+    common_fields: Vec<Field>,
+    /// Every exclude annotation (either `#[intermediate_exclude]` or
+    /// `#[intermediate_exclude(Prefix)]`) will add to this list
+    excluded_at_least_once: Vec<Field>,
+    /// Fields that are excluded with a prefix are grouped by prefix here
+    prefix_excluded: HashMap<String, Vec<Field>>,
+}
+
+impl IntermediateFields {
+    /// All groups of items that are field subsets of the current prefix
+    ///
+    /// So given a struct like:
+    ///
+    /// ```rust,ignore
+    /// #[derive(DieselIntermediate)]
+    /// struct Big {
+    ///     #[intermediate_exclude],
+    ///     id: i32,
+    ///     #[intermediate_exclude],
+    ///     meta: i32,
+    ///     #[intermediate_exclude(Outer)],
+    ///     outer: i32,
+    ///     #[intermediate_exclude(Outer, Inner)],
+    ///     outer_inner: i32,
+    ///     #[intermediate_exclude(Inner)],
+    ///     inner: i32,
+    ///
+    ///     common: i32,
+    /// }
+    /// ```
+    ///
+    /// (after diesel-derive-intermediate supports multiple intermediates)
+    ///
+    /// This would yield the following items:
+    ///
+    /// * field_differences("Outer")
+    ///   * `New, [outer, outer_inner]`
+    ///   * `Inner, [outer]`
+    /// * field_differences("Inner")
+    ///   * `New, [outer_inner, inner]`
+    ///
+    /// See also `field_difference_for_full_iter`
+    fn field_differences(&self, current_prefix: &str) -> Vec<(String, Vec<&Field>, Vec<&Field>)> {
+        // except for the current fields and the extra filter, this is
+        // identical to the function below
+        let current_fields = &self.prefix_excluded[current_prefix];
+
+        self._field_differences_inner(current_prefix, current_fields)
+    }
+
+    /// All groups of items that are field subsets of the complete item
+    ///
+    /// So given a struct like:
+    ///
+    /// ```rust,ignore
+    /// #[derive(DieselIntermediate)]
+    /// struct Big {
+    ///     #[intermediate_exclude],
+    ///     id: i32,
+    ///     #[intermediate_exclude],
+    ///     meta: i32,
+    ///     #[intermediate_exclude(Outer)],
+    ///     outer: i32,
+    ///     #[intermediate_exclude(Outer, Inner)],
+    ///     outer_inner: i32,
+    ///     #[intermediate_exclude(Inner)],
+    ///     inner: i32,
+    ///
+    ///     common: i32,
+    /// }
+    /// ```
+    ///
+    /// (after diesel-derive-intermediate supports multiple intermediates)
+    ///
+    /// This would yield the following items:
+    ///
+    /// * field_difference_for_full_iter()
+    ///   * `New, [id, meta, outer, outer_inner, inner]`
+    ///   * `Outer, [id, meta, inner]`
+    ///   * `Inner, [id, meta, outer]`
+    ///
+    /// See also `field_differences`
+    fn field_differences_full(&self) -> Vec<(String, Vec<&Field>, Vec<&Field>)> {
+        let current_fields = &self.excluded_at_least_once;
+
+        self._field_differences_inner("__", current_fields)
+    }
+
+    fn _field_differences_inner<'s>(
+        &'s self,
+        current_prefix: &str,
+        current_fields: &'s [Field],
+    ) -> Vec<(String, Vec<&'s Field>, Vec<&'s Field>)> {
+        self.prefix_excluded
+            .iter()
+            .chain(vec![(&"New".to_string(), &self.common_fields)].into_iter())
+            .filter(|&(prefix, _)| prefix != current_prefix)
+            .filter_map(|(prefix, other_excluded_fields)| {
+                let prefix = prefix.clone();
+                let other_fields: HashSet<&Field> =
+                    HashSet::from_iter(other_excluded_fields.iter());
+                let field_difference = current_fields
+                    .iter()
+                    .filter(|f| !other_fields.contains(f))
+                    .collect::<Vec<_>>();
+                let field_sames = current_fields
+                    .iter()
+                    .filter(|f| other_fields.contains(f))
+                    .collect::<Vec<_>>();
+
+                if !field_difference.is_empty() {
+                    Some((prefix, field_difference, field_sames))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 fn field_status(field: &Field) -> ExcludeAttr {
@@ -189,7 +440,7 @@ fn field_status(field: &Field) -> ExcludeAttr {
     for a in &field.attrs {
         match a.value {
             MetaItem::Word(ref ident) if ident == EXCLUDE => {
-                return Excluded;
+                return Excluded(field.clone());
             }
             MetaItem::List(ref ident, ref vals) if ident == EXCLUDE && vals.len() == 1 => {
                 // but, if the field is marked with some prefix, then we

--- a/tests/begin.rs
+++ b/tests/begin.rs
@@ -8,8 +8,7 @@ extern crate diesel_derive_intermediate;
 #[derive(DieselIntermediate)]
 #[intermediate_derive(Debug)]
 struct Val {
-    #[intermediate_exclude]
-    id: i32,
+    #[intermediate_exclude] id: i32,
     /// has a docstring
     other: &'static str,
 }
@@ -22,10 +21,8 @@ fn builds() {
 #[derive(DieselIntermediate)]
 #[intermediate_derive(Debug)]
 struct Complex {
-    #[intermediate_exclude]
-    id: i32,
-    #[intermediate_exclude(MyPrefix)]
-    oid: i32,
+    #[intermediate_exclude] id: i32,
+    #[intermediate_exclude(MyPrefix)] oid: i32,
     /// has a docstring
     other: &'static str,
 }

--- a/tests/diesel-interaction.rs
+++ b/tests/diesel-interaction.rs
@@ -1,9 +1,9 @@
 #[macro_use]
-extern crate diesel_derive_intermediate;
-#[macro_use]
 extern crate diesel;
 #[macro_use]
 extern crate diesel_codegen;
+#[macro_use]
+extern crate diesel_derive_intermediate;
 
 use diesel::prelude::*;
 use diesel::expression::sql;
@@ -40,39 +40,33 @@ table! {
 }
 
 mod items {
-    use super::{mycologists, rusts, mikes};
+    use super::{mikes, mycologists, rusts};
 
-    #[derive(DieselIntermediate)]
-    #[derive(Debug, Clone, PartialEq, Identifiable, Insertable, Queryable)]
+    #[derive(DieselIntermediate, Debug, Clone, PartialEq, Identifiable, Insertable, Queryable)]
     #[intermediate_derive(Debug, PartialEq, Insertable)]
     #[table_name = "mycologists"]
     pub struct Mycologist {
-        #[intermediate_exclude]
-        pub id: i32,
+        #[intermediate_exclude] pub id: i32,
         pub rust_count: i32,
     }
 
-    #[derive(DieselIntermediate)]
-    #[derive(Debug, Clone, PartialEq, Identifiable, Insertable, Queryable)]
+    #[derive(DieselIntermediate, Debug, Clone, PartialEq, Identifiable, Insertable, Queryable)]
     #[intermediate_derive(Debug, PartialEq, Insertable)]
     #[intermediate_table_name = "mikes"]
     #[table_name = "mycologists"]
     pub struct Scientist {
-        #[intermediate_exclude]
-        pub id: i32,
+        #[intermediate_exclude] pub id: i32,
         pub rust_count: i32,
     }
 
-    #[derive(DieselIntermediate)]
-    #[derive(Debug, Clone, PartialEq, Identifiable, Insertable, Queryable, Associations)]
-    #[intermediate_derive(Debug, PartialEq, Insertable)]
+    #[derive(DieselIntermediate, Debug, Clone, PartialEq, Identifiable, Insertable, Queryable,
+             Associations)]
+    #[intermediate_derive(Clone, Debug, PartialEq, Insertable)]
     #[table_name = "rusts"]
     #[belongs_to(Mycologist)]
     pub struct Rust {
-        #[intermediate_exclude]
-        pub id: i32,
-        #[intermediate_exclude(Captured)]
-        pub mycologist_id: i32,
+        #[intermediate_exclude] pub id: i32,
+        #[intermediate_exclude(Captured)] pub mycologist_id: i32,
         pub life_cycle_stage: i32,
     }
 }
@@ -89,7 +83,9 @@ fn setup() -> SqliteConnection {
             rust_count INTEGER NOT NULL
         )",
     );
-    setup.execute(&conn).expect("Can't create table: mycologists");
+    setup
+        .execute(&conn)
+        .expect("Can't create table: mycologists");
     let setup = sql::<diesel::types::Bool>(
         "
         CREATE TABLE rusts (
@@ -137,7 +133,7 @@ fn can_insert_mycologist() {
 fn can_insert_intermediate() {
     let conn = setup();
 
-    let rust = NewRust {
+    let new_rust = NewRust {
         life_cycle_stage: 0,
     };
     let mike = NewMycologist { rust_count: 0 };
@@ -152,10 +148,16 @@ fn can_insert_intermediate() {
         .first(&conn)
         .unwrap();
 
+    let _similar_mike = Mycologist::from_new_mycologist(created_mike.id, mike);
+
     let captured_rust = CapturedRust {
         mycologist_id: created_mike.id,
-        life_cycle_stage: rust.life_cycle_stage,
+        life_cycle_stage: new_rust.life_cycle_stage,
     };
+
+    let captured_rust_from_new = CapturedRust::from_new_rust(6, new_rust.clone());
+    let _rust_from_captured = Rust::from_captured_rust(7, captured_rust_from_new);
+    let _rust_from_new = Rust::from_new_rust(8, 9, new_rust);
 
     diesel::insert(&captured_rust)
         .into(rusts::table)


### PR DESCRIPTION
When you have only one property that is added on top of an intermediate it is
much nicer to be able to consume the intermediate struct and just the extra
fields.